### PR TITLE
fix example code to support newer seleniumwire versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ PASSWORD = "your_password"
 ENDPOINT = "pr.oxylabs.io:7777"
 
 
-def chrome_proxy(user: str, password: str, endpoint: str) -> dict:
+def get_chrome_proxy(user: str, password: str, endpoint: str) -> dict:
     wire_options = {
         "proxy": {
             "http": f"http://{user}:{password}@{endpoint}",
@@ -76,9 +76,13 @@ def chrome_proxy(user: str, password: str, endpoint: str) -> dict:
 def execute_driver():
     options = webdriver.ChromeOptions()
     options.headless = True
-    proxies = chrome_proxy(USERNAME, PASSWORD, ENDPOINT)
+    seleniumwire_options = {
+        **get_chrome_proxy(USERNAME, PASSWORD, ENDPOINT),
+        "driver_path": ChromeDriverManager().install(),
+    }
     driver = webdriver.Chrome(
-        ChromeDriverManager().install(), options=options, seleniumwire_options=proxies
+        options=options,
+        seleniumwire_options=seleniumwire_options,
     )
     try:
         driver.get("https://ip.oxylabs.io/")

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ PASSWORD = "your_password"
 ENDPOINT = "pr.oxylabs.io:7777"
 
 
-def chrome_proxy(user: str, password: str, endpoint: str) -> dict:
+def get_chrome_proxy(user: str, password: str, endpoint: str) -> dict:
     wire_options = {
         "proxy": {
             "http": f"http://{user}:{password}@{endpoint}",
@@ -22,9 +22,13 @@ def chrome_proxy(user: str, password: str, endpoint: str) -> dict:
 def execute_driver():
     options = webdriver.ChromeOptions()
     options.headless = True
-    proxies = chrome_proxy(USERNAME, PASSWORD, ENDPOINT)
+    seleniumwire_options = {
+        **get_chrome_proxy(USERNAME, PASSWORD, ENDPOINT),
+        "driver_path": ChromeDriverManager().install(),
+    }
     driver = webdriver.Chrome(
-        ChromeDriverManager().install(), options=options, seleniumwire_options=proxies
+        options=options,
+        seleniumwire_options=seleniumwire_options,
     )
     try:
         driver.get("https://ip.oxylabs.io/")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-webdriver-manager
-selenium-wire
+webdriver-manager>=4.0.1
+selenium-wire>=5.1.0


### PR DESCRIPTION
Updated code to support newer versions of seleniumwire library, fixing the duplicated options error. webdriver_manager configuration should be passed with options dictionary as driver_path.